### PR TITLE
Add plugin to recognize generated sources

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'checkstyle'
     id 'com.github.spotbugs' version '5.0.13'
     id 'antlr'
+    id 'eclipse'
 }
 
 group 'br.com.portugol_reverso'
@@ -66,4 +67,16 @@ generateGrammarSource {
 spotbugs {
     showProgress = false
     excludeFilter = file("src/main/resources/spotbugs-supression.xml")
+}
+
+//////////////////// ECLIPSE CONFIGS //////////////////////////////////////
+eclipse {
+    classpath {
+        containers 'org.eclipse.buildship.core.gradleclasspathcontainer'
+        file.whenMerged { cp ->
+            def entries = cp.entries;
+            src = new org.gradle.plugins.ide.eclipse.model.SourceFolder('build/generated-src/antlr', null)
+            entries.add(src)
+        } 
+    }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Change build.gradle file to add eclipse plugin. It allows the VSCode IDE to recognize the files generated by ANTLR4 plugin.